### PR TITLE
Add rolling and shifting cuda transform functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # rapids-kaggle-utils
 High level utility functions for using Rapids on Kaggle Competitions
+
+## cu_utils/transform
+Widely used group transform functions implemented in numba/cuda.
+They can be used within cudf's apply_grouped functions.
+Example notebooks:
+https://www.kaggle.com/aerdem4/ion-lofo-importance-on-gpu-via-rapids-xgboost
+https://www.kaggle.com/aerdem4/m5-lofo-feature-importance

--- a/cu_utils/transform.py
+++ b/cu_utils/transform.py
@@ -39,3 +39,37 @@ def cu_min_transform(x, y_out):
 
     for i in range(cuda.threadIdx.x, len(x), cuda.blockDim.x):
         y_out[i] = res[0]
+
+
+def get_cu_shift_transform(shift_by, null_val=-1):
+    def cu_shift_transform(x, y_out):
+        for i in range(cuda.threadIdx.x, len(x), cuda.blockDim.x):
+            y_out[i] = null_val
+            if 0 <= i-shift_by < len(x):
+                y_out[i] = x[i-shift_by]
+    return cu_shift_transform
+
+
+def get_cu_rolling_mean_transform(window, null_val=-1):
+    def cu_rolling_mean_transform(x, y_out):
+        for i in range(cuda.threadIdx.x, len(x), cuda.blockDim.x):
+            y_out[i] = 0
+            if i >= window-1:
+                for j in range(cuda.threadIdx.y, window, cuda.blockDim.y):
+                    cuda.atomic.add(y_out, i, x[i-j])
+                y_out[i] /= window
+            else:
+                y_out[i] = null_val
+    return cu_rolling_mean_transform
+
+
+def get_cu_rolling_max_transform(window, null_val=-1):
+    def cu_rolling_max_transform(x, y_out):
+        for i in range(cuda.threadIdx.x, len(x), cuda.blockDim.x):
+            y_out[i] = -math.inf
+            if i >= window-1:
+                for j in range(cuda.threadIdx.y, window, cuda.blockDim.y):
+                    cuda.atomic.max(y_out, i, x[i-j])
+            else:
+                y_out[i] = null_val
+    return cu_rolling_max_transform

--- a/tests/cu_utils/test_transform.py
+++ b/tests/cu_utils/test_transform.py
@@ -1,5 +1,6 @@
 from numba import cuda
 from cu_utils.transform import cu_mean_transform, cu_min_transform, cu_max_transform
+from cu_utils.transform import get_cu_shift_transform, get_cu_rolling_mean_transform, get_cu_rolling_max_transform
 import numpy as np
 
 SIZE = 128
@@ -33,4 +34,61 @@ def test_cu_max_transform():
     cuda.jit(cu_max_transform)(arr, res)
 
     np.testing.assert_almost_equal(res, np.max(arr))
+    np.testing.assert_equal(res.shape[0], SIZE)
+
+
+def test_cu_shift_transform():
+    arr = np.random.rand(SIZE)
+    res = np.zeros(SIZE)
+    shift = 3
+    null_val = -1
+
+    cuda.jit(get_cu_shift_transform(shift_by=shift, null_val=null_val))(arr, res)
+
+    np.testing.assert_equal(res[shift:], arr[:-shift])
+    np.testing.assert_equal(res[:shift], null_val)
+    np.testing.assert_equal(res.shape[0], SIZE)
+
+    res = np.zeros(SIZE)
+    shift = -4
+
+    cuda.jit(get_cu_shift_transform(shift_by=shift, null_val=null_val))(arr, res)
+
+    np.testing.assert_equal(res[:shift], arr[-shift:])
+    np.testing.assert_equal(res[shift:], null_val)
+    np.testing.assert_equal(res.shape[0], SIZE)
+
+
+def test_cu_rolling_mean_transform():
+    arr = np.random.rand(SIZE)
+    res = np.zeros(SIZE)
+    window = 3
+    null_val = -1
+
+    cuda.jit(get_cu_rolling_mean_transform(window=window, null_val=null_val))(arr, res)
+
+    expected = arr.copy()
+    for i in range(1, window):
+        expected += np.roll(arr, i)
+    expected /= window
+
+    np.testing.assert_equal(res[window-1:], expected[window-1:])
+    np.testing.assert_equal(res[:window-1], null_val)
+    np.testing.assert_equal(res.shape[0], SIZE)
+
+
+def test_cu_rolling_max_transform():
+    arr = np.random.rand(SIZE)
+    res = np.zeros(SIZE)
+    window = 5
+    null_val = -1
+
+    cuda.jit(get_cu_rolling_max_transform(window=window, null_val=null_val))(arr, res)
+
+    expected = arr.copy()
+    for i in range(1, window):
+        expected = np.maximum(np.roll(arr, i), expected)
+
+    np.testing.assert_equal(res[window-1:], expected[window-1:])
+    np.testing.assert_equal(res[:window-1], null_val)
     np.testing.assert_equal(res.shape[0], SIZE)


### PR DESCRIPTION
Numba cuda functions for using shift and rolling on groupby transform operations.
They will be provided as parameters to apply_grouped function of cudf dataframes.